### PR TITLE
Port to Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.11)
+cmake_policy(SET CMP0020 NEW)
+cmake_policy(SET CMP0043 NEW)
 
 include(cmake/Translations.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,28 @@ cmake_policy(SET CMP0043 NEW)
 
 include(cmake/Translations.cmake)
 
-find_package(Qt4 REQUIRED QtCore QtGui QtNetwork QtXml)
-add_definitions(${QT_DEFINITIONS})
-include(${QT_USE_FILE})
+option(BUILD_WITH_QT4 "Build qtsparkle with Qt4" ON)
+if(BUILD_WITH_QT4)
+  find_package(Qt4 REQUIRED QtCore QtGui QtNetwork QtXml)
+  add_definitions(${QT_DEFINITIONS})
+  include(${QT_USE_FILE})
+
+  macro(qt_add_resources)
+    qt4_add_resources(${ARGN})
+  endmacro()
+
+  set(QT_SUFFIX "")
+else()
+  find_package(Qt5 REQUIRED COMPONENTS Core Network Xml Widgets)
+
+  macro(qt_add_resources)
+    qt5_add_resources(${ARGN})
+  endmacro()
+
+  set(QT_LIBRARIES Qt5::Core Qt5::Network Qt5::Widgets)
+  set(QT_SUFFIX "-qt5")
+endif()
+
 
 SET(CMAKE_C_FLAGS    "${CMAKE_C_FLAGS} -Wall")
 SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall")

--- a/README.md
+++ b/README.md
@@ -55,3 +55,5 @@ will check for updates as soon as your application returns to the event loop.
         connect(ui_->check_for_updates, SIGNAL(clicked()),
                 updater, SLOT(CheckNow());
     }
+
+For Qt5 you need to include #include <qtsparkle-qt5/Updater>.

--- a/cmake/Translations.cmake
+++ b/cmake/Translations.cmake
@@ -47,5 +47,5 @@ macro(compile_translations outfiles ts_dir qrc_name qrc_dir)
   endforeach()
 
   file(APPEND ${qrc_filepath} "</qresource></RCC>")
-  qt4_add_resources(${outfiles} ${qrc_filepath})
+  qt_add_resources(${outfiles} ${qrc_filepath})
 endmacro()

--- a/exampleapp/CMakeLists.txt
+++ b/exampleapp/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
-
 include_directories(${CMAKE_BINARY_DIR}/include)
 
 set(SOURCES

--- a/exampleapp/mainwindow.cpp
+++ b/exampleapp/mainwindow.cpp
@@ -22,7 +22,11 @@
 
 #include "mainwindow.h"
 
+#if QT_VERSION < QT_VERSION_CHECK( 5, 0, 0 )
 #include <qtsparkle/Updater>
+#else
+#include <qtsparkle-qt5/Updater>
+#endif
 
 #include <QPushButton>
 #include <QUrl>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,26 +20,11 @@ set(SOURCES
   updater.cpp
 )
 
-set(MOC_SOURCES
-  followredirects.h
-  uicontroller.h
-  updatechecker.h
-  updatedialog.h
-  updater.h
-)
-
-set(UI_SOURCES
-  updatedialog.ui
-)
-
 add_public_header(updater.h Updater)
-
-qt4_wrap_cpp(MOC ${MOC_SOURCES})
-qt4_wrap_ui(UIC ${UI_SOURCES})
 
 add_translation_template(TRANSLATION_TEMPLATE
   ${CMAKE_CURRENT_SOURCE_DIR}/translations.ts
-  ${SOURCES} ${MOC_SOURCES} ${UI_SOURCES}
+  ${SOURCES}
 )
 
 compile_translations(SOURCES
@@ -84,9 +69,13 @@ compile_translations(SOURCES
 
 add_library(qtsparkle
   ${SOURCES}
-  ${MOC}
-  ${UIC}
   ${TRANSLATION_TEMPLATE}
+)
+
+set_target_properties(qtsparkle
+  PROPERTIES
+    AUTOMOC ON
+    AUTOUIC ON
 )
 
 target_link_libraries(qtsparkle

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,10 @@
 function(add_public_header oldname newname)
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/${oldname}"
-    "${CMAKE_BINARY_DIR}/include/qtsparkle/${newname}"
+    "${CMAKE_BINARY_DIR}/include/qtsparkle${QT_SUFFIX}/${newname}"
     COPY_ONLY)
-  install(FILES "${CMAKE_BINARY_DIR}/include/qtsparkle/${newname}"
-          DESTINATION include/qtsparkle)
+  install(FILES "${CMAKE_BINARY_DIR}/include/qtsparkle${QT_SUFFIX}/${newname}"
+          DESTINATION include/qtsparkle${QT_SUFFIX})
 endfunction(add_public_header)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
@@ -76,6 +76,7 @@ set_target_properties(qtsparkle
   PROPERTIES
     AUTOMOC ON
     AUTOUIC ON
+    OUTPUT_NAME qtsparkle${QT_SUFFIX}
 )
 
 target_link_libraries(qtsparkle

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
-
 function(add_public_header oldname newname)
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/${oldname}"


### PR DESCRIPTION
Hi,

this allows building QtSparkle with Qt4 and Qt5.
I bumped the CMake version requirement to keep the changes minimal (Qt5 target support, Automoc, Autouic).


Regards,
Domme