### PR TITLE
fix build with Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,9 @@ if(BUILD_WITH_QT4)
 
   set(QT_SUFFIX "")
 else()
-  find_package(Qt5 REQUIRED COMPONENTS Core Network Xml Widgets)
+  find_package(Qt5 REQUIRED COMPONENTS Core Network Xml Widgets LinguistTools)
+  set(QT_LUPDATE_EXECUTABLE ${Qt5_LUPDATE_EXECUTABLE})
+  set(QT_LRELEASE_EXECUTABLE ${Qt5_LRELEASE_EXECUTABLE})
 
   macro(qt_add_resources)
     qt5_add_resources(${ARGN})


### PR DESCRIPTION
QT_LUPDATE_EXECUTABLE and QT_LRELEASE_EXECUTABLE are not defined for Qt5 build:
```
$ make
Scanning dependencies of target qtsparkle_automoc
[  1%] Automatic moc and uic for target qtsparkle
Generating ui_updatedialog.h
Generating moc_followredirects.cpp
Generating moc_uicontroller.cpp
Generating moc_updatechecker.cpp
Generating moc_updatedialog.cpp
Generating moc_updater.cpp
[  1%] Built target qtsparkle_automoc
[  3%] Generating af.qm
/bin/sh: 1: -silent: not found
src/CMakeFiles/qtsparkle.dir/build.make:61: recipe for target 'src/af.qm' failed
make[2]: *** [src/af.qm] Error 127
CMakeFiles/Makefile2:86: recipe for target 'src/CMakeFiles/qtsparkle.dir/all' failed
make[1]: *** [src/CMakeFiles/qtsparkle.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
```