### PR TITLE
Replace signals/slots with Q_SIGNALS/Q_SLOTS

### DIFF
--- a/src/followredirects.h
+++ b/src/followredirects.h
@@ -38,11 +38,11 @@ public:
 
   QNetworkReply* reply() const;
 
-signals:
+Q_SIGNALS:
   void Finished();
   void RedirectLimitReached();
 
-private slots:
+private Q_SLOTS:
   void FinishedSlot();
 
 private:

--- a/src/uicontroller.h
+++ b/src/uicontroller.h
@@ -44,7 +44,7 @@ public:
   void SetIcon(const QIcon& icon);
   void SetVersion(const QString& version);
 
-public slots:
+public Q_SLOTS:
   void CheckStarted();
   void UpdateAvailable(AppCastPtr appcast);
   void UpToDate();

--- a/src/updatechecker.h
+++ b/src/updatechecker.h
@@ -43,13 +43,13 @@ public:
   void SetVersion(const QString& version);
   void Check(const QUrl& appcast_url, bool override_user_skip);
 
-signals:
+Q_SIGNALS:
   void CheckStarted();
   void UpdateAvailable(AppCastPtr appcast);
   void UpToDate();
   void CheckFailed(const QString& reason);
 
-private slots:
+private Q_SLOTS:
   void Finished();
   void RedirectLimitReached();
 

--- a/src/updatedialog.h
+++ b/src/updatedialog.h
@@ -44,10 +44,10 @@ public:
   void SetIcon(const QIcon& icon);
   void SetVersion(const QString& version);
 
-public slots:
+public Q_SLOTS:
   void ShowUpdate(AppCastPtr appcast);
 
-private slots:
+private Q_SLOTS:
   void ReleaseNotesReady();
   void Install();
   void Skip();

--- a/src/updater.h
+++ b/src/updater.h
@@ -81,12 +81,12 @@ public:
   // Minimum value is one hour (3600000)
   void SetUpdateInterval(int msec);
 
-public slots:
+public Q_SLOTS:
   // Checks for updates now.  You probably want to call this from a menu item
   // in your application's main window.
   void CheckNow();
 
-private slots:
+private Q_SLOTS:
   void AutoCheck();
 
 protected:


### PR DESCRIPTION
When including `updater.h` in application with `QT_NO_SIGNALS_SLOTS_KEYWORDS`, it fails to build. To fix this change all signals/slots to use Q_SIGNALS/Q_SLOTS directly.