### PR TITLE
Install CMake files and drop Qt 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,64 +1,67 @@
+cmake_minimum_required(VERSION 3.13)
 project(qtsparkle)
 
-cmake_minimum_required(VERSION 2.8.12)
-cmake_policy(SET CMP0020 NEW)
-cmake_policy(SET CMP0043 NEW)
+if(POLICY CMP0020)
+  cmake_policy(SET CMP0020 NEW)
+endif()
+if(POLICY CMP0043)
+  cmake_policy(SET CMP0043 NEW)
+endif()
 
+include(CMakePackageConfigHelpers)
 include(cmake/Translations.cmake)
 
-option(BUILD_WITH_QT4 "Build qtsparkle with Qt 4" OFF)
+option(BUILD_STATIC_LIBS "Static build" OFF)
+option(BUILD_SHARED_LIBS "Shared build" ON)
+
 option(BUILD_WITH_QT5 "Build qtsparkle with Qt 5" OFF)
 option(BUILD_WITH_QT6 "Build qtsparkle with Qt 6" OFF)
 
-if (NOT BUILD_WITH_QT4 AND NOT BUILD_WITH_QT5 AND NOT BUILD_WITH_QT6)
-  set(BUILD_WITH_QT5 ON)
+if(NOT MSVC)
+  add_compile_options(-Wall)
 endif()
 
-option(BUILD_STATIC "Static build" OFF)
-if(BUILD_WITH_QT4)
-  find_package(Qt4 REQUIRED QtCore QtGui QtNetwork QtXml)
-  add_definitions(${QT_DEFINITIONS})
-  include(${QT_USE_FILE})
+if(BUILD_WITH_QT5)
+  set(QT_VERSION_MAJOR 5)
+elseif(BUILD_WITH_QT6)
+  set(QT_VERSION_MAJOR 6)
+endif()
 
-  macro(qt_add_resources)
-    qt4_add_resources(${ARGN})
-  endmacro()
+if(NOT QT_VERSION_MAJOR)
+  message(FATAL_ERROR "You need to set either BUILD_WITH_QT5, BUILD_WITH_QT6 or QT_VERSION_MAJOR.")
+endif()
 
-  set(QT_SUFFIX "")
-  message("- Building with Qt 4")
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED Core Network Widgets LinguistTools)
+set(QT_LIBRARIES Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Network Qt${QT_VERSION_MAJOR}::Widgets)
+set(QT_LUPDATE_EXECUTABLE Qt${QT_VERSION_MAJOR}::lupdate)
+set(QT_LRELEASE_EXECUTABLE Qt${QT_VERSION_MAJOR}::lrelease)
+set(QT_SUFFIX "-qt${QT_VERSION_MAJOR}")
+add_definitions(${QT_DEFINITIONS})
 
-elseif(BUILD_WITH_QT5)
-  find_package(Qt5 REQUIRED COMPONENTS Core Network Widgets LinguistTools)
-  set(QT_LUPDATE_EXECUTABLE ${Qt5_LUPDATE_EXECUTABLE})
-  set(QT_LRELEASE_EXECUTABLE ${Qt5_LRELEASE_EXECUTABLE})
-
+if(QT_VERSION_MAJOR EQUAL 5 AND Qt5Core_VERSION VERSION_LESS 5.15.0)
   macro(qt_add_resources)
     qt5_add_resources(${ARGN})
   endmacro()
-
-  set(QT_LIBRARIES Qt5::Core Qt5::Network Qt5::Widgets)
-  set(QT_SUFFIX "-qt5")
-  message("- Building with Qt 5")
-
-elseif(BUILD_WITH_QT6)
-  find_package(Qt6 REQUIRED COMPONENTS Core Network Widgets LinguistTools)
-  set(QT_LUPDATE_EXECUTABLE Qt6::lupdate)
-  set(QT_LRELEASE_EXECUTABLE Qt6::lrelease)
-
-  macro(qt_add_resources)
-    qt6_add_resources(${ARGN})
-  endmacro()
-
-  set(QT_LIBRARIES Qt6::Core Qt6::Network Qt6::Widgets)
-  set(QT_SUFFIX "-qt6")
-  message("- Building with Qt 6")
-else()
-  message(FATAL_ERROR "You need to set either BUILD_WITH_QT4, BUILD_WITH_QT5 or BUILD_WITH_QT6.")
 endif()
 
-
-SET(CMAKE_C_FLAGS    "${CMAKE_C_FLAGS} -Wall")
-SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall")
+message("- Building with Qt ${QT_VERSION_MAJOR}")
 
 add_subdirectory(src)
 add_subdirectory(exampleapp)
+
+install(EXPORT ${PROJECT_NAME}${QT_SUFFIX}Targets
+  NAMESPACE ${PROJECT_NAME}${QT_SUFFIX}::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}${QT_SUFFIX}
+)
+
+configure_package_config_file(${PROJECT_NAME}Config.cmake.in ${PROJECT_NAME}${QT_SUFFIX}Config.cmake INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}${QT_SUFFIX})
+
+install(TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}${QT_SUFFIX}Targets
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  FRAMEWORK DESTINATION ${FRAMEWORK_INSTALL_DIR}
+)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}${QT_SUFFIX}Config.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}${QT_SUFFIX})

--- a/exampleapp/CMakeLists.txt
+++ b/exampleapp/CMakeLists.txt
@@ -9,16 +9,16 @@ add_executable(exampleapp
   ${SOURCES}
 )
 
-if(BUILD_STATIC AND WIN32)
-  set(LIBS
+target_link_libraries(exampleapp
+  ${PROJECT_NAME}
+  ${QT_LIBRARIES}
+  ${LIBS}
+)
+
+if(WIN32 AND BUILD_STATIC_LIBS)
+  target_link_libraries(exampleapp
     -lssl
     -lcrypto
     -lws2_32
   )
 endif()
-
-target_link_libraries(exampleapp
-  qtsparkle
-  ${QT_LIBRARIES}
-  ${LIBS}
-)

--- a/qtsparkleConfig.cmake.in
+++ b/qtsparkleConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/qtsparkle@QT_SUFFIX@Targets.cmake")
+
+check_required_components(qtsparkle@QT_SUFFIX@)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,10 @@
 function(add_public_header oldname newname)
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/${oldname}"
-    "${CMAKE_BINARY_DIR}/include/qtsparkle${QT_SUFFIX}/${newname}"
+    "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}${QT_SUFFIX}/${newname}"
     COPYONLY)
-  install(FILES "${CMAKE_BINARY_DIR}/include/qtsparkle${QT_SUFFIX}/${newname}"
-          DESTINATION include/qtsparkle${QT_SUFFIX})
+  install(FILES "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}${QT_SUFFIX}/${newname}"
+          DESTINATION include/${PROJECT_NAME}${QT_SUFFIX})
 endfunction(add_public_header)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
@@ -67,25 +67,31 @@ compile_translations(SOURCES
   "zh_TW"
 )
 
-add_library(qtsparkle
+add_library(${PROJECT_NAME}
   ${SOURCES}
   ${TRANSLATION_TEMPLATE}
 )
 
-set_target_properties(qtsparkle
-  PROPERTIES
-    AUTOMOC ON
-    AUTOUIC ON
-    OUTPUT_NAME qtsparkle${QT_SUFFIX}
+set_target_properties(${PROJECT_NAME} PROPERTIES
+  CMAKE_CXX_STANDARD 17
+  CMAKE_CXX_STANDARD_REQUIRED ON
+  AUTOMOC ON
+  AUTOUIC ON
+  OUTPUT_NAME ${PROJECT_NAME}${QT_SUFFIX}
+  PUBLIC_HEADER Updater
 )
 
-target_link_libraries(qtsparkle
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE QTSPARKLE_BUILD) # dllexport
+else()
+  target_compile_definitions(${PROJECT_NAME} PUBLIC QTSPARKLE_STATIC) # suppress dllimport
+endif()
+
+target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
 )
-
-install(TARGETS qtsparkle
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION bin
-  RUNTIME DESTINATION bin
-)
-

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -1,58 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
-<context>
-    <name>UpdateDialog</name>
-    <message>
-        <location filename="updatedialog.ui" line="14"/>
-        <source>Software Update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="updatedialog.ui" line="59"/>
-        <source>Release notes:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="updatedialog.ui" line="71"/>
-        <source>Skip this version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="updatedialog.ui" line="91"/>
-        <source>Remind me later</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="updatedialog.ui" line="98"/>
-        <source>Install update</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
+<TS version="2.1">
 <context>
     <name>qtsparkle::UiController</name>
     <message>
-        <location filename="uicontroller.cpp" line="79"/>
+        <location filename="uicontroller.cpp" line="81"/>
         <source>Checking for updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="uicontroller.cpp" line="80"/>
+        <location filename="uicontroller.cpp" line="82"/>
         <source>Checking for updates to %1, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="uicontroller.cpp" line="107"/>
+        <location filename="uicontroller.cpp" line="109"/>
         <source>No updates available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="uicontroller.cpp" line="108"/>
+        <location filename="uicontroller.cpp" line="110"/>
         <source>You already have the latest version of %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="uicontroller.cpp" line="123"/>
+        <location filename="uicontroller.cpp" line="125"/>
         <source>Update check failed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -73,22 +45,22 @@
 <context>
     <name>qtsparkle::Updater</name>
     <message>
-        <location filename="updater.cpp" line="163"/>
+        <location filename="updater.cpp" line="185"/>
         <source>Check for updates automatically?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="updater.cpp" line="164"/>
+        <location filename="updater.cpp" line="186"/>
         <source>Should %1 automatically check for updates?  You can always check for updates manually from the menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="updater.cpp" line="166"/>
+        <location filename="updater.cpp" line="188"/>
         <source>Check automatically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="updater.cpp" line="167"/>
+        <location filename="updater.cpp" line="189"/>
         <source>Don&apos;t check</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/updater.h
+++ b/src/updater.h
@@ -30,6 +30,16 @@ class QIcon;
 class QNetworkAccessManager;
 class QUrl;
 
+#ifdef QTSPARKLE_STATIC
+#  define QTSPARKLE_EXPORT
+#else
+#  ifdef QTSPARKLE_BUILD
+#    define QTSPARKLE_EXPORT Q_DECL_EXPORT
+#  else
+#    define QTSPARKLE_EXPORT Q_DECL_IMPORT
+#  endif
+#endif
+
 namespace qtsparkle {
 
 // Loads qtsparkle's translations from the .ts files compiled into the library,
@@ -37,7 +47,7 @@ namespace qtsparkle {
 // function if you want to use a non-default language for qtsparkle.  If you
 // do not call this function, it will be called with the default language
 // (QLocale::system().name()) the first time qtsparkle::Updater is created.
-void LoadTranslations(const QString& language);
+QTSPARKLE_EXPORT void LoadTranslations(const QString& language);
 
 
 // The Updater is the main class in qtsparkle that you should use in your
@@ -49,7 +59,7 @@ void LoadTranslations(const QString& language);
 // permission, it will check for updates automatically on startup.
 // Checking for updates and displaying dialogs is done after the application
 // returns to the event loop, not in the constructor.
-class Updater : public QObject {
+class QTSPARKLE_EXPORT Updater : public QObject {
   Q_OBJECT
 
 public:


### PR DESCRIPTION
Install CMake files so `find_package` can be used, added `Q_DECL_EXPORT` / `Q_DECL_IMPORT` to fix linking with MSVC, also dropped Qt 4 since it's been end of life for a long time.